### PR TITLE
just to be able to upload 4 images without js

### DIFF
--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -31,6 +31,22 @@
       = f.fields_for :images do |fin|
         = fin.file_field :image, class: 'hidden', required: true
 
+    .new-upload__image
+      .new-upload__image-dd
+        %pre
+          ドラッグアンドドロップ
+          またはクリックしてファイルをアップロード
+      = f.fields_for :images do |fin|
+        = fin.file_field :image, class: 'hidden', required: true
+
+    .new-upload__image
+      .new-upload__image-dd
+        %pre
+          ドラッグアンドドロップ
+          またはクリックしてファイルをアップロード
+      = f.fields_for :images do |fin|
+        = fin.file_field :image, class: 'hidden', required: true
+
   .new-itembox
     %span
       商品名


### PR DESCRIPTION
# WHAT

本来はjqueryで画像アップロードを実装すべきだが、haml上のfile_fieldを4つにして、とにかく画像を4つアップロードできるようにした

# WHY

後続タスクのボトルネックとなってしまったための対処