### PR TITLE
payjpの変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem 'enum_help'
   gem 'recaptcha', require: "recaptcha/rails"
 
   gem 'payjp'
+  gem 'gon'
 
 group :production do
   gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,10 @@ GEM
     formatador (0.2.5)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    gon (6.2.1)
+      actionpack (>= 3.0)
+      multi_json
+      request_store (>= 1.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -257,6 +261,8 @@ GEM
       ffi (~> 1.0)
     recaptcha (4.13.1)
       json
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -365,6 +371,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-rails
+  gon
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/javascripts/items_show.js
+++ b/app/assets/javascripts/items_show.js
@@ -5,4 +5,11 @@ $(document).on('turbolinks:load',function() {
     $(this).addClass('active');
     $('.owl-stage').css( { left: -300 * i + "px" } )
   });
+
+  // 住所とかが無いと購入できない
+  $('.buy-red').on('click', function() {
+    if (!(gon.address)) {
+      alert('住所など、基本情報を登録してください');
+    }
+  });
 });

--- a/app/assets/javascripts/order-new.js
+++ b/app/assets/javascripts/order-new.js
@@ -1,14 +1,5 @@
-// $(document).on('turbolinks:load',function() {
-//   $('.buy-main-content__process-msg').on('click', function() {
-//     console.log('777');
-//     return false;
-//     // var usersCard
-//     var user_id = $
-//     $.ajax({
-//       type: '',
-//       url: '',
-//       data: {id: }
-//     })
-//   })
-// });
-
+$(function() {
+  $("#not-click").on('mouseover', function() {
+    $(this).css("cursor","no-drop");
+  });
+});

--- a/app/assets/javascripts/pay.js
+++ b/app/assets/javascripts/pay.js
@@ -1,9 +1,57 @@
-// $(function() {
-//   $(document).on('click','#payjp_checkout_box input:button', function() {
-//     // console.log('777');
+$(function() {
+  // @paybtnをリンクっぽくする
+  $('.order-item__pay-btn__box-paypay').on('mouseover', function() {
+    $(this).css('text-decoration', 'underline');
+  })
+  $('.order-item__pay-btn__box-paypay').on('mouseout', function() {
+    $(this).css('text-decoration', 'none');
+  })
 
-//     var iframe = $('#payjp-checkout-iframe').contents().find('html').html();
-//     console.log(iframe)
+  // 支払いの一連の流れ
+  $('.order-item__pay-btn__box-paypay').on('click', function() {
+    Payjp.setPublicKey(gon.key);
 
-//   })
-// });
+    // payアクションのurlを取得
+    var url = $('#paycard').attr('action')
+
+    // 失敗した時のリダイレクト先
+    var redidect = $('#order-show-go').attr('href')
+    console.log(redidect);
+
+    // フォームのカード情報を取得してcardにまとめる
+    var num = $('.pay-num').val();
+    var cvc = $('.pay-cvc').val();
+    var exp_m = $('.pay-exp-m').val();
+    var exp_y = $('.pay-exp-y').val();
+
+    var card = {
+      number: num,
+      cvc: cvc,
+      exp_month: exp_m,
+      exp_year: exp_y
+    };
+
+    // payjp.jsを使ってトークンを作成
+    Payjp.createToken(card, function(status, response) {
+      if (status == 200) {
+        var token = response.id;
+
+        $.ajax({
+          url: url,
+          type: 'POST',
+          data: {payjp_token: token},
+        })
+        .done(function(message) {
+          alert('お支払いありがとうございます、出品者の発送をお待ちください！');
+        })
+        .fail(function() {
+          alert('通信エラーで支払い失敗です！もう一度試してみてください！');
+        })
+
+      } else {
+        alert('カードが使えないようです！残念！');
+        $(location).attr('href', redidect);
+      };
+    });
+  })
+});

--- a/app/assets/stylesheets/modules/new.scss
+++ b/app/assets/stylesheets/modules/new.scss
@@ -71,18 +71,25 @@
       }
       &__error-text{
         font-size: 12px;
-        color: red;
+        color: $red;
         padding-top: 25px;
       }
       &__process{
         background-color: gray;
         opacity: 0.9;
-        width: 270px;
         margin: 10px auto 0;
         margin-bottom: 40px;
+        width: 270px;
+        &-red {
+          margin: 40px auto;
+          background-color: $red;
+          line-height: 50px;
+          width: 270px;
+          text-decoration: none;
+        }
       }
       &__image{
-          background-color: white;
+          background-color: $white;
           text-align: center;
       }
       &__process-msg{
@@ -94,19 +101,20 @@
       }
       &__point-msg{
         padding-top: 15px;
+        width: 270px;
       }
     }
   }
   &-user-info{
-    background-color: white;
+    background-color: $white;
     border-bottom: solid 2px;
     border-color: rgb(245,245,245);
     text-align: left;
     padding-top: 3px;
     &__inner{
-      height: 90px;
       width: 350px;
       margin: 10px auto 20px;
+      @include clearfix();
       &__msg{
         font-size: 13px;
         font-weight: bold;
@@ -126,10 +134,11 @@
       }
       &__fix{
         font-size: 12px;
-        color: blue;
+        @include link($blue);
         float: right;
         opacity: 0.7;
         padding-top: 20px;
+        font-weight: bold;
       }
     }
   }
@@ -149,34 +158,39 @@
     float: right;
   }
   &-options{
-    background-color: white;
+    background-color: $white;
     padding-top: 3px;
     border-top: solid 2px;
     border-color: rgb(245,245,245);
     &__inner{
-      height: 60px;
       width: 350px;
-      margin: 10px auto 15px;
+      margin: 15px auto 15px;
+      @include clearfix();
       &__msg{
         font-size: 13px;
         font-weight: bold;
-        padding-bottom: 5px;
       }
       &__name{
-        font-size: 13px;
-        padding-top: 20px;
+        font-size: 12px;
+        padding-top: 10px;
       }
       &__fix{
         font-size: 12px;
-        color: blue;
+        font-weight: bold;
         float: right;
         opacity: 0.7;
         padding-top: 20px;
+        @include link($blue);
       }
     }
   }
 }
 
+.take-commit {
+  width: 270px;
+  line-height: 50px;
+  color: $white;
+}
 .chanel-img{
   object-fit: cover;
   width: 130px;

--- a/app/assets/stylesheets/modules/order/create.scss
+++ b/app/assets/stylesheets/modules/order/create.scss
@@ -22,8 +22,12 @@
       width: 50%;
       text-align: center;
       margin: 20px auto;
+      cursor: pointer;
       &__do {
         @include link($white);
+      }
+      &-paypay {
+        color: $white;
       }
     }
     &__message {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    gon.address = current_user.address.present?
     @item = Item.find(params[:id])
     @comments = @item.comments
     @comment = Comment.new

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -102,6 +102,8 @@
     %span.price ￥14,500
     %span.tax （税込）
     %span.shipping-fee 送料込み
+
+  = Gon::Base.render_data
   .item-buy-btn
     = link_to new_item_order_path(params[:id]), class: "buy-red" do
       購入画面に進む

--- a/app/views/orders/_pay.html.haml
+++ b/app/views/orders/_pay.html.haml
@@ -1,0 +1,8 @@
+%script{:src => "https://js.pay.jp/", :type => "text/javascript"}
+= Gon::Base.render_data
+.order-card-form
+  = form_with url: pay_user_order_path(current_user.id, @order), method: :post, id: 'paycard', type: 'hidden' do |f|
+    = f.hidden_field :number, class: 'pay-num', placeholder: 'type a message', value: "#{current_user.credit_card.number}"
+    = f.hidden_field :cvc, class: 'pay-cvc', placeholder: 'type a message', value: "#{current_user.credit_card.security_code}"
+    = f.hidden_field :exp_month, class: 'pay-exp-m', placeholder: 'type a message', value: "#{current_user.credit_card.expiration_month}"
+    = f.hidden_field :exp_year, class: 'pay-exp-y', placeholder: 'type a message', value: "#{current_user.credit_card.expriration_year}"

--- a/app/views/orders/create.html.haml
+++ b/app/views/orders/create.html.haml
@@ -32,10 +32,11 @@
 
   .order-item__pay-btn
     .order-item__pay-btn__box
-      = form_with url: pay_user_order_path(current_user.id, @order), method: :post do |f|
-        %script.payjp-button{"data-key" => "#{PAYJP_PUBLIC_KEY}", "data-partial" => "true", :src => "https://checkout.pay.jp/", :type => "text/javascript"}
-        = f.submit '入金'
+      .order-item__pay-btn__box-paypay
+        登録されているカードで支払う
 
     .order-item__pay-btn__box
-      = link_to item_order_path(params[:item_id], @order), class: "order-item__pay-btn__box__do" do
+      = link_to item_order_path(params[:item_id], @order), class: "order-item__pay-btn__box__do", id: 'order-show-go' do
         今すぐはしない
+
+  = render 'pay'

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -3,7 +3,7 @@
     .c-single-main__head__text 購入を確定しますか？
   .buy-content
     .buy-main-content__image
-      = image_tag "img.jpeg", alt: "sample", class: "chanel-img"
+      = image_tag (@image), alt: "sample", class: "chanel-img"
       .buy-main-content
         .buy-main-content__name
           = @item.name
@@ -19,10 +19,16 @@
             %li.payment-msg 支払い金額
             %li.payment-price
               = @item.price
-        .buy-main-content__error-text 配送先と支払い方法の入力を完了してください
-        .buy-main-content__process
-          = link_to item_orders_path(params[:item_id]),method: :post, class: "buy-main-content__process-msg" do
-            購入する
+        - if current_user.credit_card.present?
+          .buy-main-content__process-red
+            = link_to item_orders_path(params[:item_id]),method: :post, class: "buy-main-content__process-msg" do
+              .take-commit
+                購入する
+        - else
+          .buy-main-content__error-text 配送先と支払い方法の入力を完了してください
+          .buy-main-content__process
+            .take-commit#not-click
+              購入する
       .buy-user-info
         .buy-user-info__inner
           .buy-user-info__inner__msg 配送先
@@ -30,11 +36,20 @@
           .buy-user-info__inner__address 東京都渋谷区道玄坂1-1-1
           .buy-user-info__inner__name
             = current_user.nickname
-          = link_to do
-            .buy-user-info__inner__fix 変更する >
+          =link_to new_user_card_path(current_user), class: 'buy-user-info__inner__fix' do
+            変更する >
+
         .payment-options
           .payment-options__inner
-            .payment-options__inner__msg 支払い方法 /
+            .payment-options__inner__msg
+              支払い方法
             .payment-options__inner__name
-            =link_to do
-              .payment-options__inner__fix 変更する >
+              .card-num-box
+                - if current_user.credit_card.present?
+                  ************#{current_user.credit_card.number.match(/\d{4}$/)}
+                  %br/
+                  #{current_user.credit_card.expiration_month}/#{current_user.credit_card.expriration_year.to_s.match(/\d{2}$/)}
+                - else
+                  &frasl;
+            =link_to new_user_card_path(current_user), class: 'payment-options__inner__fix' do
+              変更する >

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -33,14 +33,13 @@
     .order-menu__list
       = current_user.nickname
 
-  - if @order.status == "stage0" && current_user == @order.user
+  .order-item__pay-btn
     .order-item__pay-btn__box
-      = form_with url: pay_user_order_path(current_user.id, @order), method: :post do |f|
-        %script.payjp-button{"data-key" => "#{PAYJP_PUBLIC_KEY}", "data-partial" => "true", :src => "https://checkout.pay.jp/", :type => "text/javascript"}
-        = f.submit '入金'
+      .order-item__pay-btn__box-paypay
+        = @paybtn
 
   .order-item__pay-btn
-    =link_to item_order_path(params[:item_id],params[:id]), method: :patch, class: "order-item__pay-btn__box__do" do
+    = link_to item_order_path(params[:item_id],params[:id]), method: :patch, id: 'order-show-go', class: "order-item__pay-btn__box__do" do
       .order-item__pay-btn__box
         = @btn
 
@@ -49,7 +48,8 @@
       = @message
 
   .order-item__pay-btn
-    =link_to item_order_path(params[:item_id],params[:id]), method: :delete, class: "order-item__pay-btn__box__do" do
+    = link_to item_order_path(params[:item_id],params[:id]), method: :delete, class: "order-item__pay-btn__box__do" do
       .order-item__pay-btn__box
         = @cancel_message
 
+  = render 'pay'


### PR DESCRIPTION
ビューに隠しフォームを置いてpayjp.jsにてトークン取得、後にajaxでコントローラーに送信して支払いする方法に変更しました。現時点で一番本家に近いかと思います。これが私には限界です。

その他、住所などが登録していないと購入ページに行けなかったり、カード情報が無いと購入ボタンが押せなかったりなど変更加えてます。